### PR TITLE
ignore any script errors that arise from opening the page

### DIFF
--- a/src/runCoverage.js
+++ b/src/runCoverage.js
@@ -111,6 +111,11 @@ async function runCoverage () {
   })
   const page = await browser.newPage()
 
+  log.info(`Opening (X)HTML file (may take a few minutes)`)
+  log.debug(`Opening "${url}"`)
+  await page.goto(url)
+  log.debug(`Opened "${url}"`)
+
   const browserLog = log.child({browser: 'console'})
   page.on('console', msg => {
     switch (msg.type()) {
@@ -140,11 +145,6 @@ async function runCoverage () {
     log.fatal('browser-ERROR', msgText)
     process.exit(STATUS_CODE.ERROR)
   })
-
-  log.info(`Opening (X)HTML file (may take a few minutes)`)
-  log.debug(`Opening "${url}"`)
-  await page.goto(url)
-  log.debug(`Opened "${url}"`)
 
   log.debug(`Adding sizzleJS`)
   await page.mainFrame().addScriptTag({


### PR DESCRIPTION
this includes any `<script>` tags in the page that might not run. They should not affect coverage since we are testing for CSS coverage of the HTML