### PR TITLE
Fix logic bug on source map existence check

### DIFF
--- a/src/runCoverage.js
+++ b/src/runCoverage.js
@@ -238,7 +238,7 @@ async function generateLcovStr (coverageOutput) {
   let sourceMapPath
 
   // Skip files that do not have a sourcemap
-  if (commander.ignoreSourceMap || /sourceMappingURL=([^ ]*)/.exec(CSS_STR)) {
+  if (commander.ignoreSourceMap || !/sourceMappingURL=([^ ]*)/.test(CSS_STR)) {
     sourceMapConsumer = null
     sourceMapPath = 'noSourceMapProvided'
   } else {


### PR DESCRIPTION
This PR fixes a logic bug that causes the source map loading code to not run if a `sourceMappingURL` element is found.